### PR TITLE
Install OCaml toolchain and OPAM dependencies using ocaml_repositories()

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git_repository(
     commit = "18685e1bc5ad22e425f502355087747a6638f51a",
 )
 
-load("@io_bazel_rules_ocaml//ocaml:ocaml.bzl", "ocaml_repositories")
+load("@io_bazel_rules_ocaml//ocaml:repo.bzl", "ocaml_repositories")
 ocaml_repositories() 
 # this downloads the OPAM precompiled binaries into your bazel cache, but doesn't use them directly yet.
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Rules
 
-* [ocaml_native_binary](#ocaml_native_binary)
-* [ocaml_bytecode_binary](#ocaml_bytecode_binary)
+* [ocaml_native_binary](#ocaml_native_binary/ocaml_bytecode_binary)
+* [ocaml_bytecode_binary](#ocaml_native_binary/ocaml_bytecode_binary)
 * [ocaml_interface](#ocaml_interface)
 
 ## Overview
@@ -11,8 +11,6 @@
 Build OCaml with Bazel. Very experimental. API is expected to change.
 
 ## Setup
-
-This is a wrapper around `ocamlbuild`. Ensure that the OCaml toolchain (`ocamlbuild`, `ocamlfind`, etc) is reachable in your `PATH`. TODO: have `ocaml_repositories` download the toolchain.
 
 Add the following to your `WORKSPACE` file.
 
@@ -24,47 +22,136 @@ git_repository(
 )
 
 load("@io_bazel_rules_ocaml//ocaml:repo.bzl", "ocaml_repositories")
-ocaml_repositories() 
-# this downloads the OPAM precompiled binaries into your bazel cache, but doesn't use them directly yet.
+ocaml_repositories(
+    opam_packages = {
+        # Put your OPAM dependencies here
+        "lwt": "3.1.0",
+        "yojson": "1.4.0",
+    },
+)
 ```
 
 and this to your BUILD files.
 
 ```bzl
-load("@io_bazel_rules_ocaml//ocaml:ocaml.bzl", "ocaml_native_binary", "ocaml_bytecode_binary")
+load("@io_bazel_rules_ocaml//ocaml:ocaml.bzl", "ocaml_native_binary", "ocaml_bytecode_binary", "ocaml_interface")
 ```
 
-## Examples
+## Rules
 
-### ocaml_native_binary
+### ocaml_native_binary/ocaml_bytecode_binary
 
-Generates a native binary.
+Generates a native binary using `ocamlopt` or bytecode binary using `ocamlc`.
+
+```bzl
+ocaml_native_library(name, srcs, src_root, opam_packages)
+ocaml_bytecode_library(name, srcs, src_root, opam_packages)
+```
+
+#### Example
 
 ```bzl
 ocaml_native_binary(
     name = "hello_world",
     srcs = glob(["examples/*.ml"]),
+    src_root = "examples/hello_world.ml",
     opam_packages = ["pkg_foo", "pkg_bar"],
-    src_root = "examples/hello_world.ml", # Optional, defaults to the first main.ml found while loading the sources.
 )
-```
 
-### ocaml_bytecode_binary
-
-Generates a bytecode binary.
-
-```bzl
 ocaml_bytecode_binary(
-    name = "hello_world",
-    srcs = glob(["examples/*.ml"]),
+    name = "other_binary",
+    srcs = [
+      "examples/foo.ml",
+      "examples/bar.ml",
+      "examples/entry.ml",
+    ],
+    src_root = "examples/entry.ml",
     opam_packages = ["pkg_foo", "pkg_bar"],
-    src_root = "examples/hello_world.ml", # Optional, defaults to the first main.ml found while loading the sources.
 )
 ```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this target</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>srcs</code></td>
+      <td>
+        <p><code>List of labels, required</code></p>
+        <p>List of OCaml <code>.ml</code> source files used to build the
+        library</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>src_root</code></td>
+      <td>
+        <p><code>Label, optional</code></p>
+        <p>The OCaml <code>.ml</code> source file used for the binary's entry point.<p>
+        <p>Defaults to <code>main.ml</code> if not specified.
+      </td>
+    </tr>
+    <tr>
+      <td><code>opam_packages</code></td>
+      <td>
+        <p><code>List of strings, optional</code></p>
+        <p>The name of the OPAM package dependencies required by this binary.</p>
+        <p>The packages (and their versions) must already be defined in your WORKSPACE file's <code>ocaml_repositories()</code>.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ### ocaml_interface
 
-Generates a `.mli` file of the source.
+Generates a `.mli` file of the source file.
+
+```bzl
+ocaml_interface(name, src)
+```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this target</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>src</code></td>
+      <td>
+        <p><code>Label</code></p>
+        <p>The OCaml <code>.ml</code> source file used for generating the interface file<p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+#### Example
 
 ```bzl
 ocaml_interface(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
 workspace(name = "io_bazel_rules_ocaml")
 
-load("//ocaml:ocaml.bzl", "ocaml_repositories")
+load("//ocaml:repo.bzl", "ocaml_repositories")
 ocaml_repositories()

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,9 +1,19 @@
-load("//ocaml:ocaml.bzl", "ocaml_native_binary", "ocaml_interface")
+load("//ocaml:ocaml.bzl", "ocaml_native_binary", "ocaml_bytecode_binary", "ocaml_interface")
 
 ocaml_native_binary(
-    name = "hello_world",
-    srcs = glob(["*.ml"]),
-    src_root = "hello_world.ml",
+    name = "hello_world_native",
+    srcs = [
+        "test.ml", 
+        "hello_world.ml",
+    ],
+)
+
+ocaml_bytecode_binary(
+    name = "hello_world_bytecode",
+    srcs = [
+        "test.ml", 
+        "hello_world.ml",
+    ],
 )
 
 ocaml_interface(

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -2,16 +2,18 @@ load("//ocaml:ocaml.bzl", "ocaml_native_binary", "ocaml_bytecode_binary", "ocaml
 
 ocaml_native_binary(
     name = "hello_world_native",
+    src_root = "hello_world.ml",
     srcs = [
-        "test.ml", 
+        "test.ml",
         "hello_world.ml",
     ],
 )
 
 ocaml_bytecode_binary(
     name = "hello_world_bytecode",
+    src_root = "hello_world.ml",
     srcs = [
-        "test.ml", 
+        "test.ml",
         "hello_world.ml",
     ],
 )

--- a/examples/hello_world.ml
+++ b/examples/hello_world.ml
@@ -1,3 +1,1 @@
-open Test
-
-let () = print_endline ("Hello world"^(string_of_int foo));;
+let () = print_endline ("Hello world"^(string_of_int Test.foo));;

--- a/ocaml/BUILD
+++ b/ocaml/BUILD
@@ -9,11 +9,3 @@ config_setting(
     name = "k8",
     values = {"host_cpu": "k8"},
 )
-
-filegroup(
-    name = "opam",
-    srcs = select({
-        ":darwin": ["@opam_darwin_x86_64//file"],
-        ":k8": ["@opam_linux_x86_64//file"],
-    }),
-)

--- a/ocaml/repo.bzl
+++ b/ocaml/repo.bzl
@@ -1,0 +1,103 @@
+OCAML_VERSION = "4.04.0"
+OCAMLBUILD_VERSION = "0.11.0"
+COMPILER_NAME = "ocaml-base-compiler.%s" % OCAML_VERSION
+DEBUG_QUIET = True 
+
+_opam_binary_attrs = {
+    "_opam": attr.label(
+        default = Label("@opam//:opam"),
+        executable = True,
+        single_file = True,
+        allow_files = True,
+        cfg = "host",
+    ),
+}
+
+# Set up OCaml's toolchain (ocamlc, ocamlbuild, ocamlfind)
+_OCAML_TOOLCHAIN_BUILD = """
+filegroup(
+  name = "ocamlc",
+  srcs = ["opam_dir/{compiler}/bin/ocamlc"],
+  visibility = ["//visibility:public"],
+)
+
+filegroup(
+  name = "ocamlbuild",
+  srcs = ["opam_dir/{compiler}/bin/ocamlbuild"],
+  visibility = ["//visibility:public"],
+)
+""".format(compiler = COMPILER_NAME)
+
+def _ocaml_toolchain_impl(repository_ctx):
+  opam_dir = "opam_dir"
+  opam_path = repository_ctx.path(repository_ctx.attr._opam)
+
+  # Initialize opam and its root directory
+  repository_ctx.execute([
+      opam_path, 
+      "init", 
+      "--root", opam_dir, 
+      "--no-setup", 
+      "--comp", COMPILER_NAME
+  ], quiet = DEBUG_QUIET)
+
+  # Download the OCaml compiler
+  repository_ctx.execute([
+      opam_path, 
+      "switch", COMPILER_NAME, 
+      "--root", opam_dir
+  ], quiet = DEBUG_QUIET)
+
+  # Install OCamlbuild
+  repository_ctx.execute([
+      opam_path, 
+      "install", 
+      "ocamlbuild=%s" % OCAMLBUILD_VERSION, 
+      "--yes", 
+      "--root", opam_dir
+  ], quiet = DEBUG_QUIET)
+
+  repository_ctx.file("WORKSPACE", "", False)
+  repository_ctx.file("BUILD", _OCAML_TOOLCHAIN_BUILD, False)
+
+_ocaml_toolchain_repo = repository_rule(
+    implementation = _ocaml_toolchain_impl,
+    attrs = _opam_binary_attrs,
+)
+
+def _ocaml_toolchain():
+  _ocaml_toolchain_repo(name = "ocaml_toolchain")
+
+# Set up OPAM
+def _opam_binary_impl(repository_ctx):
+  os_name = repository_ctx.os.name.lower()
+  if os_name.find("windows") != -1:
+    fail("Windows is not supported yet, sorry!")
+  elif os_name.startswith("mac os"):
+    repository_ctx.download(
+        "https://github.com/ocaml/opam/releases/download/2.0.0-beta4/opam-2.0.0-beta4-x86_64-darwin",
+        "opam",
+        "d23c06f4f03de89e34b9d26ebb99229a725059abaf6242ae3b9e9bf946b445e1",
+        executable = True,
+    )
+  else:
+    repository_ctx.download(
+        "https://github.com/ocaml/opam/releases/download/2.0.0-beta4/opam-2.0.0-beta4-x86_64-linux",
+        "opam",
+        "3de4b78a263d4c1e46760c26bdc2b02fdbce980a9fc9141385058c2b0174708c",
+        executable = True,
+    )
+  repository_ctx.file("WORKSPACE", "", False)
+  repository_ctx.file("BUILD", "exports_files([\"opam\"])", False)
+
+_opam_binary_repo = repository_rule(
+    implementation = _opam_binary_impl,
+    attrs = {}
+)
+
+def _opam_binary():
+  _opam_binary_repo(name = "opam")
+
+def ocaml_repositories():
+  _opam_binary()
+  _ocaml_toolchain()


### PR DESCRIPTION
This PR removes the need for OCaml to be installed on the system.

`ocaml_repositories(opam_packages = { .. }` now downloads the entire OCaml toolchain including ocamlbuild, ocamlfind and OPAM itself. 

Users can also specify OPAM dependencies and their versions; see README for an example.

Fixes #1 #2.